### PR TITLE
Fix CHECK_GPU_ERROR

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ __global__ void func(unified_array<Data> data_array)
 func<<<1, 1>>>(data_array);
 
 // Prefetch data to CPU
-data_array.prefetch_to_cpu();
+data_array.prefetch_cpu();
 ```
 
 Conversion between CPU and GPU arrays:

--- a/include/gpu_ptr.hpp
+++ b/include/gpu_ptr.hpp
@@ -409,8 +409,11 @@ namespace gpu_smart_ptr
         }
         SIGSEGV_DEPRECATED __host__ __device__ reference front() noexcept { return *begin(); }
         SIGSEGV_DEPRECATED __host__ __device__ const_reference front() const noexcept { return *begin(); }
-        SIGSEGV_DEPRECATED __host__ __device__ reference back() noexcept { return *(--end()); }
-        SIGSEGV_DEPRECATED __host__ __device__ const_reference back() const noexcept { return *(--end()); }
+        SIGSEGV_DEPRECATED __host__ __device__ reference back() noexcept { return *(data() + base::size_ - 1); }
+        SIGSEGV_DEPRECATED __host__ __device__ const_reference back() const noexcept
+        {
+            return *(data() + base::size_ - 1);
+        }
         __host__ __device__ pointer data() noexcept { return std::get<0>(base::data_); }
         __host__ __device__ pointer data() const noexcept { return std::get<0>(base::data_); }
 
@@ -706,8 +709,8 @@ namespace gpu_smart_ptr
         }
         __host__ __device__ reference front() noexcept { return *begin(); }
         __host__ __device__ const_reference front() const noexcept { return *begin(); }
-        __host__ __device__ reference back() noexcept { return *(--end()); }
-        __host__ __device__ const_reference back() const noexcept { return *(--end()); }
+        __host__ __device__ reference back() noexcept { return *(data() + base::size_ - 1); }
+        __host__ __device__ const_reference back() const noexcept { return *(data() + base::size_ - 1); }
         __host__ __device__ pointer data() noexcept { return std::get<0>(base::data_); }
         __host__ __device__ pointer data() const noexcept { return std::get<0>(base::data_); }
 

--- a/include/gpu_ptr.hpp
+++ b/include/gpu_ptr.hpp
@@ -417,7 +417,7 @@ namespace gpu_smart_ptr
         __host__ __device__ pointer data() noexcept { return std::get<0>(base::data_); }
         __host__ __device__ pointer data() const noexcept { return std::get<0>(base::data_); }
 
-        __host__ __device__ array_ptr() = default;
+        array_ptr() = default;
         __host__ __device__ array_ptr(const array_ptr& r) : base(r) {}
         __host__ __device__ array_ptr(array_ptr&& r) noexcept : base(std::move(r)) {}
 
@@ -714,7 +714,7 @@ namespace gpu_smart_ptr
         __host__ __device__ pointer data() noexcept { return std::get<0>(base::data_); }
         __host__ __device__ pointer data() const noexcept { return std::get<0>(base::data_); }
 
-        __host__ __device__ unified_array_ptr() = default;
+        unified_array_ptr() = default;
         __host__ __device__ unified_array_ptr(const unified_array_ptr& r) : base(r) {}
         __host__ __device__ unified_array_ptr(unified_array_ptr&& r) noexcept : base(std::move(r)) {}
 
@@ -1203,12 +1203,12 @@ namespace gpu_smart_ptr
         using value_type = Tuple<Ts...>;
         using iterator_concept = std::random_access_iterator_tag;
 
-        __host__ __device__ soa_iterator() = default;
-        __host__ __device__ soa_iterator(const soa_iterator&) = default;
-        __host__ __device__ soa_iterator(soa_iterator&&) noexcept = default;
+        soa_iterator() = default;
+        soa_iterator(const soa_iterator&) = default;
+        soa_iterator(soa_iterator&&) noexcept = default;
 
-        __host__ __device__ soa_iterator& operator=(const soa_iterator&) = default;
-        __host__ __device__ soa_iterator& operator=(soa_iterator&&) noexcept = default;
+        soa_iterator& operator=(const soa_iterator&) = default;
+        soa_iterator& operator=(soa_iterator&&) noexcept = default;
 
         __host__ __device__ explicit soa_iterator(std::tuple<Ts*...> ptrs) : ptrs_(ptrs) {}
 
@@ -1384,7 +1384,7 @@ namespace gpu_smart_ptr
             return std::get<N>(base::data_);
         }
 
-        __host__ __device__ soa_ptr() = default;
+        soa_ptr() = default;
         __host__ __device__ soa_ptr(const soa_ptr& r) : base(r) {}
         __host__ __device__ soa_ptr(soa_ptr&& r) noexcept : base(std::move(r)) {}
 
@@ -1659,7 +1659,7 @@ namespace gpu_smart_ptr
             return std::get<N>(base::data_);
         }
 
-        __host__ __device__ unified_soa_ptr() = default;
+        unified_soa_ptr() = default;
         __host__ __device__ unified_soa_ptr(const unified_soa_ptr& r) : base(r) {}
         __host__ __device__ unified_soa_ptr(unified_soa_ptr&& r) noexcept : base(std::move(r)) {}
 
@@ -1844,9 +1844,9 @@ namespace gpu_smart_ptr
         static constexpr auto has_prefetch = requires(const ArrayType& a) { a.prefetch(); };
 
     public:
-        __host__ __device__ jagged_array() = default;
-        __host__ __device__ jagged_array(const jagged_array&) = default;
-        __host__ __device__ jagged_array(jagged_array&&) noexcept = default;
+        jagged_array() = default;
+        jagged_array(const jagged_array&) = default;
+        jagged_array(jagged_array&&) noexcept = default;
 
         template <std::ranges::forward_range Range>
         requires std::ranges::sized_range<Range> &&
@@ -1880,8 +1880,8 @@ namespace gpu_smart_ptr
             }
         }
 
-        __host__ __device__ jagged_array& operator=(const jagged_array&) = default;
-        __host__ __device__ jagged_array& operator=(jagged_array&&) noexcept = default;
+        jagged_array& operator=(const jagged_array&) = default;
+        jagged_array& operator=(jagged_array&&) noexcept = default;
 
         using base::begin;
         using base::empty;

--- a/include/gpu_ptr.hpp
+++ b/include/gpu_ptr.hpp
@@ -872,6 +872,10 @@ namespace gpu_smart_ptr
         {
             if (base::size_ == 0) return;
             CHECK_GPU_ERROR(detail::gpuMemPrefetchAsync(data(), sizeof(ValueType) * base::size_, device_id, stream));
+            if constexpr (has_prefetch)
+            {
+                for (std::size_t i = 0; i < base::size_; ++i) data()[i].prefetch(device_id, stream);
+            }
         }
         __host__ void prefetch(detail::gpuStream_t stream = 0) const { prefetch(detail::get_device_id(), stream); }
 
@@ -916,7 +920,6 @@ namespace gpu_smart_ptr
         requires std::is_default_constructible_v<T> && requires(const ValueType& v) { static_cast<U>(v); }
         __host__ T to() const
         {
-            prefetch_cpu();
             if constexpr (gpu_array_ptr<T>)
             {
                 // array_ptr<U> or unified_array_ptr<U>

--- a/include/gpu_ptr.hpp
+++ b/include/gpu_ptr.hpp
@@ -412,7 +412,7 @@ namespace gpu_smart_ptr
         SIGSEGV_DEPRECATED __host__ __device__ reference back() noexcept { return *(--end()); }
         SIGSEGV_DEPRECATED __host__ __device__ const_reference back() const noexcept { return *(--end()); }
         __host__ __device__ pointer data() noexcept { return std::get<0>(base::data_); }
-        __host__ __device__ const_pointer data() const noexcept { return std::get<0>(base::data_); }
+        __host__ __device__ pointer data() const noexcept { return std::get<0>(base::data_); }
 
         __host__ __device__ array_ptr() = default;
         __host__ __device__ array_ptr(const array_ptr& r) : base(r) {}
@@ -709,7 +709,7 @@ namespace gpu_smart_ptr
         __host__ __device__ reference back() noexcept { return *(--end()); }
         __host__ __device__ const_reference back() const noexcept { return *(--end()); }
         __host__ __device__ pointer data() noexcept { return std::get<0>(base::data_); }
-        __host__ __device__ const_pointer data() const noexcept { return std::get<0>(base::data_); }
+        __host__ __device__ pointer data() const noexcept { return std::get<0>(base::data_); }
 
         __host__ __device__ unified_array_ptr() = default;
         __host__ __device__ unified_array_ptr(const unified_array_ptr& r) : base(r) {}

--- a/include/gpu_runtime_api.hpp
+++ b/include/gpu_runtime_api.hpp
@@ -81,6 +81,7 @@ namespace gpu_smart_ptr::detail
     }
 #endif
     __host__ inline decltype(auto) gpuSetDevice(int device) { return ::hipSetDevice(device); }
+    __host__ inline decltype(auto) gpuGetLastError() { return ::hipGetLastError(); }
 
 #else
 
@@ -139,6 +140,7 @@ namespace gpu_smart_ptr::detail
         return ::cudaOccupancyAvailableDynamicSMemPerBlock(dynamicSmem, f, numBlocks, blockSize);
     }
     __host__ inline decltype(auto) gpuSetDevice(int device) { return ::cudaSetDevice(device); }
+    __host__ inline decltype(auto) gpuGetLastError() { return ::cudaGetLastError(); }
 #endif
 }  // namespace gpu_smart_ptr::detail
 

--- a/include/gpu_runtime_api.hpp
+++ b/include/gpu_runtime_api.hpp
@@ -90,7 +90,16 @@ namespace gpu_smart_ptr::detail
     __host__ inline const char* gpuGetErrorName(gpuError_t gpu_error) { return ::cudaGetErrorName(gpu_error); }
     __host__ inline const char* gpuGetErrorString(gpuError_t gpu_error) { return ::cudaGetErrorString(gpu_error); }
 
-    using gpuMemcpyKind = cudaMemcpyKind;
+    using gpuMemcpyKind = ::cudaMemcpyKind;
+    enum class gpuMemoryAdvise
+    {
+        SetReadMostly = cudaMemAdviseSetReadMostly,
+        UnsetReadMostly = cudaMemAdviseUnsetReadMostly,
+        SetPreferredLocation = cudaMemAdviseSetPreferredLocation,
+        UnsetPreferredLocation = cudaMemAdviseUnsetPreferredLocation,
+        SetAccessedBy = cudaMemAdviseSetAccessedBy,
+        UnsetAccessedBy = cudaMemAdviseUnsetAccessedBy,
+    };
 #define gpuMemcpyHostToHost cudaMemcpyHostToHost
 #define gpuMemcpyHostToDevice cudaMemcpyHostToDevice
 #define gpuMemcpyDeviceToHost cudaMemcpyDeviceToHost
@@ -121,6 +130,10 @@ namespace gpu_smart_ptr::detail
                                                        gpuStream_t stream = 0)
     {
         return ::cudaMemPrefetchAsync(devPtr, count, dstDevice, stream);
+    }
+    __host__ inline decltype(auto) gpuMemAdvise(const void* devPtr, size_t count, gpuMemoryAdvise advice, int device)
+    {
+        return ::cudaMemAdvise(devPtr, count, static_cast<cudaMemoryAdvise>(advice), device);
     }
     __host__ inline decltype(auto) gpuDeviceSynchronize() { return ::cudaDeviceSynchronize(); }
     __host__ inline decltype(auto) gpuGetDeviceCount(int* count) { return ::cudaGetDeviceCount(count); }

--- a/include/gpu_runtime_api.hpp
+++ b/include/gpu_runtime_api.hpp
@@ -29,6 +29,15 @@ namespace gpu_smart_ptr::detail
     __host__ inline const char* gpuGetErrorString(gpuError_t gpu_error) { return ::hipGetErrorString(gpu_error); }
 
     using gpuMemcpyKind = ::hipMemcpyKind;
+    enum class gpuMemoryAdvise
+    {
+        SetReadMostly = hipMemAdviseSetReadMostly,
+        UnsetReadMostly = hipMemAdviseUnsetReadMostly,
+        SetPreferredLocation = hipMemAdviseSetPreferredLocation,
+        UnsetPreferredLocation = hipMemAdviseUnsetPreferredLocation,
+        SetAccessedBy = hipMemAdviseSetAccessedBy,
+        UnsetAccessedBy = hipMemAdviseUnsetAccessedBy,
+    };
 #define gpuMemcpyHostToHost hipMemcpyHostToHost
 #define gpuMemcpyHostToDevice hipMemcpyHostToDevice
 #define gpuMemcpyDeviceToHost hipMemcpyDeviceToHost
@@ -59,6 +68,10 @@ namespace gpu_smart_ptr::detail
                                                        gpuStream_t stream = 0)
     {
         return ::hipMemPrefetchAsync(dev_ptr, count, device, stream);
+    }
+    __host__ inline decltype(auto) gpuMemAdvise(const void* devPtr, size_t count, gpuMemoryAdvise advice, int device)
+    {
+        return ::hipMemAdvise(devPtr, count, static_cast<hipMemoryAdvise>(advice), device);
     }
     __host__ inline decltype(auto) gpuDeviceSynchronize() { return ::hipDeviceSynchronize(); }
     __host__ inline decltype(auto) gpuGetDeviceCount(int* count) { return ::hipGetDeviceCount(count); }

--- a/include/gpu_runtime_api.hpp
+++ b/include/gpu_runtime_api.hpp
@@ -63,6 +63,24 @@ namespace gpu_smart_ptr::detail
     __host__ inline decltype(auto) gpuDeviceSynchronize() { return ::hipDeviceSynchronize(); }
     __host__ inline decltype(auto) gpuGetDeviceCount(int* count) { return ::hipGetDeviceCount(count); }
     __host__ inline decltype(auto) gpuGetDevice(int* device) { return ::hipGetDevice(device); }
+    __host__ inline decltype(auto) gpuStreamCreate(gpuStream_t* stream) { return ::hipStreamCreate(stream); }
+    __host__ inline decltype(auto) gpuStreamSynchronize(gpuStream_t stream) { return ::hipStreamSynchronize(stream); }
+    template <typename T>
+    __host__ decltype(auto) gpuOccupancyMaxActiveBlocksPerMultiprocessor(int* numBlocks, T f, int blockSize,
+                                                                         size_t dynSharedMemPerBlk)
+    {
+        return ::hipOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks, f, blockSize, dynSharedMemPerBlk);
+    }
+#ifdef __NVCC__
+    template <typename T>
+    __host__ inline decltype(auto) gpuOccupancyAvailableDynamicSMemPerBlock(size_t* dynamicSmem, T* f, int numBlocks,
+                                                                            int blockSize)
+    {
+        return hipCUDAErrorTohipError(
+            ::cudaOccupancyAvailableDynamicSMemPerBlock(dynamicSmem, f, numBlocks, blockSize));
+    }
+#endif
+    __host__ inline decltype(auto) gpuSetDevice(int device) { return ::hipSetDevice(device); }
 
 #else
 
@@ -106,6 +124,21 @@ namespace gpu_smart_ptr::detail
     __host__ inline decltype(auto) gpuDeviceSynchronize() { return ::cudaDeviceSynchronize(); }
     __host__ inline decltype(auto) gpuGetDeviceCount(int* count) { return ::cudaGetDeviceCount(count); }
     __host__ inline decltype(auto) gpuGetDevice(int* device) { return ::cudaGetDevice(device); }
+    __host__ inline decltype(auto) gpuStreamCreate(gpuStream_t* stream) { return ::cudaStreamCreate(stream); }
+    __host__ inline decltype(auto) gpuStreamSynchronize(gpuStream_t stream) { return ::cudaStreamSynchronize(stream); }
+    template <typename T>
+    __host__ decltype(auto) gpuOccupancyMaxActiveBlocksPerMultiprocessor(int* numBlocks, T f, int blockSize,
+                                                                         size_t dynSharedMemPerBlk)
+    {
+        return ::cudaOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks, f, blockSize, dynSharedMemPerBlk);
+    }
+    template <typename T>
+    __host__ inline decltype(auto) gpuOccupancyAvailableDynamicSMemPerBlock(size_t* dynamicSmem, T* f, int numBlocks,
+                                                                            int blockSize)
+    {
+        return ::cudaOccupancyAvailableDynamicSMemPerBlock(dynamicSmem, f, numBlocks, blockSize);
+    }
+    __host__ inline decltype(auto) gpuSetDevice(int device) { return ::cudaSetDevice(device); }
 #endif
 }  // namespace gpu_smart_ptr::detail
 

--- a/include/gpu_runtime_api.hpp
+++ b/include/gpu_runtime_api.hpp
@@ -170,24 +170,32 @@ namespace gpu_smart_ptr::detail
     __host__ inline decltype(auto) gpuGetLastError() { return ::cudaGetLastError(); }
 #endif
 
-    __host__ inline void check_gpu_error(const gpuError_t e, [[maybe_unused]] const char* f,
-                                         [[maybe_unused]] decltype(__LINE__) n)
+    __host__ inline void check_gpu_error(const gpuError_t e)
     {
         if (e != gpuSuccess)
         {
             std::stringstream s;
-#ifdef NDEBUG
             s << gpuGetErrorName(e) << " (" << static_cast<unsigned>(e) << "): " << gpuGetErrorString(e);
-#else
+            throw std::runtime_error{s.str()};
+        }
+    }
+    __host__ inline void check_gpu_error(const gpuError_t e, const char* f, decltype(__LINE__) n)
+    {
+        if (e != gpuSuccess)
+        {
+            std::stringstream s;
             s << gpuGetErrorName(e) << " (" << static_cast<unsigned>(e) << ")@" << f << "#L" << n << ": "
               << gpuGetErrorString(e);
-#endif
             throw std::runtime_error{s.str()};
         }
     }
 
 }  // namespace gpu_smart_ptr::detail
 
+#ifdef NDEBUG
+#define CHECK_GPU_ERROR(expr) (gpu_smart_ptr::detail::check_gpu_error(expr))
+#else
 #define CHECK_GPU_ERROR(expr) (gpu_smart_ptr::detail::check_gpu_error(expr, __FILE__, __LINE__))
+#endif
 
 // NOLINTEND


### PR DESCRIPTION
When I build a program with NDEBUG using Clang (but not GCC), `__FILE__` and `__LINE__` are embedded into the created binary, which seems to be an unexpected behavior. To ensure that __FILE__ and __LINE__ are not embedded with NDEBUG, I have modified CHECK_GPU_ERROR.