### PR TITLE
Disable alias templates for stride views in HIP

### DIFF
--- a/include/gpu_array.hpp
+++ b/include/gpu_array.hpp
@@ -2818,24 +2818,11 @@ namespace gpu_array
         {
             template <std::ranges::random_access_range Range>
             requires std::ranges::sized_range<Range>
-            [[nodiscard]] constexpr auto operator()(const Range& r) const noexcept
-            {
-                return stride_view<StrideType, const Range&>(r);
-            }
-            template <std::ranges::random_access_range Range>
-            requires std::ranges::sized_range<Range>
             [[nodiscard]] constexpr auto operator()(Range& r) const noexcept
             {
                 return stride_view<StrideType, Range&>(r);
             }
 
-            template <std::ranges::random_access_range Range>
-            requires std::ranges::sized_range<Range>
-            [[nodiscard]] friend constexpr std::ranges::view auto operator|(const Range& range,
-                                                                            const stride_adapter& self) noexcept
-            {
-                return self(range);
-            }
             template <std::ranges::random_access_range Range>
             requires std::ranges::sized_range<Range>
             [[nodiscard]] friend constexpr std::ranges::view auto operator|(Range& range,

--- a/include/gpu_array.hpp
+++ b/include/gpu_array.hpp
@@ -2846,13 +2846,16 @@ namespace gpu_array
         };
     }  // namespace detail
 
+#if !defined(ENABLE_HIP)
+    // The following three alias templates are also disabled in HIP because HIP does not support alias template argument
+    // deduction.
     template <std::ranges::random_access_range Range>
     using block_thread_stride_view = detail::stride_view<detail::Stride::BlockThread, Range>;
     template <std::ranges::random_access_range Range>
     using grid_thread_stride_view = detail::stride_view<detail::Stride::GridThread, Range>;
     template <std::ranges::random_access_range Range>
     using grid_block_stride_view = detail::stride_view<detail::Stride::GridBlock, Range>;
-#if !defined(ENABLE_HIP)
+
     template <std::ranges::random_access_range Range>
     using cluster_thread_stride_view = detail::stride_view<detail::Stride::ClusterThread, Range>;
     template <std::ranges::random_access_range Range>

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -2070,6 +2070,7 @@ TEST(JaggedArray, MemoryManagement)
     }
 }
 
+#if !defined(ENABLE_HIP)
 template <std::ranges::input_range T>
 requires std::ranges::input_range<std::ranges::range_value_t<T>>
 __global__ void kernel_stride(T array)
@@ -2102,7 +2103,6 @@ TEST(StrideView, HowToUse)
         for (const auto& v : inner_array) EXPECT_EQ(v, 2);
 }
 
-#if !defined(ENABLE_HIP)
 template <std::ranges::input_range T>
 requires std::ranges::input_range<std::ranges::range_value_t<T>>
 __global__ void kernel_stride3(T array)


### PR DESCRIPTION
This pull request includes the following two fixes:

### 1. Disable alias templates for stride_view in HIP

since HIP does not support alias template argument deduction.

### 2. Remove overloads for const Range& in stride_adapter

stride_adapter no longer supports rvalue references (const lvalue reference is ok).

```cpp
template <std::ranges::input_range T>
requires std::ranges::input_range<std::ranges::range_value_t<T>>
__global__ void kernel_stride(T array)
{
    for (auto& a : std::move(array) | views::grid_block_stride)
    //             ^~~~~~~~~~~~~~~~ compile error!
        for (auto& v : a | views::block_thread_stride) v = 1;
}
```